### PR TITLE
Follow NIO conventions closer

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,9 +20,9 @@ let package = Package(
     name: "Bolt",
     
     platforms: [
-        .macOS(.v10_14), 
-        .iOS(.v12),
-        .tvOS(.v12),
+        .macOS(.v10_15), 
+        .iOS(.v13),
+        .tvOS(.v13),
     ],
     
     products: [

--- a/Sources/Connection.swift
+++ b/Sources/Connection.swift
@@ -319,8 +319,6 @@ public class Connection: NSObject {
         let theEventLoop = MultiThreadedEventLoopGroup.currentEventLoop ?? MultiThreadedEventLoopGroup(numberOfThreads: 1).next()
         // print("Request running on event loop thread: \(theEventLoop.description)")
         
-        let promise = theEventLoop.makePromise(of: [Response].self)
-        
         if isConnected == false {
             print("Bolt client is not connected")
             return theEventLoop.makeFailedFuture(ConnectionError.noConnection)
@@ -336,6 +334,8 @@ public class Connection: NSObject {
 
         let maxChunkSize = Int32(Request.kMaxChunkSize)
         var accumulatedData: [Byte] = []
+        
+        let promise = theEventLoop.makePromise(of: [Response].self)
         
         func loop() {
             #if BOLT_DEBUG

--- a/Sources/Connection.swift
+++ b/Sources/Connection.swift
@@ -79,7 +79,7 @@ public class Connection: NSObject {
 
             var version: UInt32 = 0
             _ = try? self.socket.receive(expectedNumberOfBytes: 4).map { response -> (Bool) in
-                let result = response.map { bytes -> Void in
+                _ = response.map { bytes -> Void in
                     do {
                         version = try UInt32.unpack(bytes[0..<bytes.count])
                         initPromise.succeed(version != 0)

--- a/Sources/EncryptedSocket.swift
+++ b/Sources/EncryptedSocket.swift
@@ -110,7 +110,8 @@ extension NIOTSConnectionBootstrap {
             // only available starting with macOS 10.15 & iOS 13
             // let serverName = sec_protocol_metadata_get_server_name(metadata)
 
-            SecTrustEvaluateAsync(actualTrust, verifyQueue) { (trust, result) in
+            SecTrustEvaluateAsyncWithError(actualTrust, verifyQueue) { (trust, result, error) -> Void in
+            // SecTrustEvaluateAsync(actualTrust, verifyQueue) { (trust, result, error) in
 
                 var optionalSha1: String?
                 let count = SecTrustGetCertificateCount(trust)
@@ -132,11 +133,13 @@ extension NIOTSConnectionBootstrap {
                     return
                 }
 
-                switch result {
-                case .proceed, .unspecified:
+                // switch result {
+                // case .proceed, .unspecified:@
+                if result {
                     validator.didTrustCertificate(withSHA1: sha1)
                     verifyCompleteCB(true)
-                default:
+                // default:
+                } else {
                     if(!validator.shouldTrustCertificate(withSHA1: sha1)) {
                         verifyCompleteCB(false)
                     } else {

--- a/Sources/UnencryptedSocket.swift
+++ b/Sources/UnencryptedSocket.swift
@@ -94,7 +94,7 @@ public class UnencryptedSocket {
 
         self.bootstrap = bootstrap
         // print("#1")
-        bootstrap.connectTimeout(TimeAmount.milliseconds(Int64(timeout)))
+        _ = bootstrap.connectTimeout(TimeAmount.milliseconds(Int64(timeout)))
         bootstrap.connect(host: hostname, port: port).map{ theChannel -> Void in
             self.channel = theChannel
         }.whenComplete { (result) in
@@ -139,8 +139,8 @@ extension UnencryptedSocket: SocketProtocol {
         var buffer = channel.allocator.buffer(capacity: bytes.count)
         buffer.writeBytes(bytes)
         
-        let c = cnt
-        cnt = cnt + 1
+        // let c = cnt
+        // cnt = cnt + 1
         
         // print("\nSend #\(c)")
         // print(Data(bytes: bytes, count: bytes.count).hexEncodedString())

--- a/Tests/BoltTests/SocketTests.swift
+++ b/Tests/BoltTests/SocketTests.swift
@@ -79,16 +79,16 @@ extension SocketTests {
 
         let request = Request.run(statement: statement, parameters: Map(dictionary: [:]))
         
-        let promise =  try? conn.request(request)
-        promise?.whenSuccess{ responses in
+        let promise =  conn.request(request)
+        promise.whenSuccess{ responses in
 
             if responses.count == 0 {
                 XCTFail("Unexpected response for \(statement)")
             }
 
             let request = Request.pullAll()
-            let pullPromise = try? conn.request(request)
-            pullPromise?.whenSuccess { responses in
+            let pullPromise = conn.request(request)
+            pullPromise.whenSuccess { responses in
 
                 if responses.count == 0 {
                     XCTFail("Unexpected response")
@@ -102,7 +102,7 @@ extension SocketTests {
             }
         }
         
-        promise?.whenFailure({ (error) in
+        promise.whenFailure({ (error) in
             if let responseError = error as? Response.ResponseError {
                 switch responseError {
                 case let Response.ResponseError.forbiddenDueToTransactionType(message):
@@ -207,12 +207,12 @@ extension SocketTests {
         try performAsLoggedIn { (conn, dispatchGroup) in
 
             let request = Request.run(statement: stmt, parameters: Map(dictionary: [:]))
-            let promise = try? conn.request(request)
-            promise?.whenSuccess{ _ in
+            let promise = conn.request(request)
+            promise.whenSuccess{ _ in
                 XCTFail("Unexpected response")
                 exp.fulfill()
             }
-            promise?.whenFailure { _ in
+            promise.whenFailure { _ in
                 // Happy path
                 exp.fulfill()
             }
@@ -233,12 +233,12 @@ extension SocketTests {
         try? performAsLoggedIn { (conn, dispatchGroup) in
 
             let request = Request.run(statement: stmt, parameters: Map(dictionary: [:]))
-            let promise = try? conn.request(request)
+            let promise = conn.request(request)
             
-            promise?.whenSuccess { (responses) in
+            promise.whenSuccess { (responses) in
 
                 let request = Request.pullAll()
-                try? conn.request(request)?.whenSuccess { (responses) in
+                conn.request(request).whenSuccess { (responses) in
 
                     let records = responses.filter { $0.category == .record }
                     XCTAssertEqual(10000, records.count)
@@ -246,7 +246,7 @@ extension SocketTests {
                 }
             }
             
-            promise?.whenFailure{ error in
+            promise.whenFailure{ error in
                 XCTFail(String(describing: error))
                 exp.fulfill()
             }
@@ -267,9 +267,9 @@ extension SocketTests {
         try? performAsLoggedIn { (conn, dispatchGroup) in
 
             let request = Request.run(statement: stmt, parameters: Map(dictionary: [:]))
-            let promise = try? conn.request(request)
+            let promise = conn.request(request)
             
-            promise?.whenSuccess { (responses) in
+            promise.whenSuccess { (responses) in
                 
                 XCTAssertEqual(1, responses.count)
                 let fields = (responses[0].items[0] as! Map).dictionary["fields"] as! List
@@ -277,7 +277,7 @@ extension SocketTests {
 
 
                 let request = Request.pullAll()
-                try? conn.request(request)?.whenSuccess { (responses) in
+                conn.request(request).whenSuccess { (responses) in
 
                     
                     let records = responses.filter { $0.category == .record && ($0.items[0] as! List).items.count == 2 }
@@ -287,7 +287,7 @@ extension SocketTests {
                 }
             }
             
-            promise?.whenFailure{ error in
+            promise.whenFailure{ error in
                 XCTFail(String(describing: error))
                 exp.fulfill()
             }

--- a/Tests/BoltTests/UnencryptedSocketTests.swift
+++ b/Tests/BoltTests/UnencryptedSocketTests.swift
@@ -54,9 +54,9 @@ class UnencryptedSocketTests: XCTestCase {
         socketTests?.templateUnwind(self)
     }
 
-    func testUnwindWithToNodes() throws {
+    func testUnwindWithToNodes() {
         XCTAssertNotNil(socketTests)
-        try socketTests?.templateUnwindWithToNodes(self)
+        socketTests?.templateUnwindWithToNodes(self)
     }
 
 }


### PR DESCRIPTION
Remove `throws` and use `makeFailedFuture` instead.
Always return an `EventLoopFuture` instead of an Optional (returning a failed future in that condition).